### PR TITLE
Defer react-pdf import for exams list

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import React, { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
Dynamically import React-PDF components to prevent a `hasOwnProperty` crash on initial page render.

The `TypeError: hasOwnProperty` from `@react-pdf/renderer` occurred because the component was being instantiated during the initial render of the exams list, before any exam data was available. This change ensures PDF components are only loaded and rendered after a user clicks the 'PDF' button and valid exam data is fetched.

---

[Open in Web](https://cursor.com/agents?id=bc-1ba3f2f3-cc60-46dc-b3ee-ffdb0c69a483) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1ba3f2f3-cc60-46dc-b3ee-ffdb0c69a483)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)